### PR TITLE
Check for top level struct being null before trying to check members

### DIFF
--- a/farms_network/core/edge.pyx
+++ b/farms_network/core/edge.pyx
@@ -34,15 +34,15 @@ cdef class PyEdge:
         self.edge.nparameters = 0
 
     def __dealloc__(self):
-        if self.edge.source is not NULL:
-            free(self.edge.source)
-        if self.edge.target is not NULL:
-            free(self.edge.target)
-        if self.edge.type is not NULL:
-            free(self.edge.type)
-        if self.edge.parameters is not NULL:
-            free(self.edge.parameters)
         if self.edge is not NULL:
+            if self.edge.source is not NULL:
+                free(self.edge.source)
+            if self.edge.target is not NULL:
+                free(self.edge.target)
+            if self.edge.type is not NULL:
+                free(self.edge.type)
+            if self.edge.parameters is not NULL:
+                free(self.edge.parameters)
             free(self.edge)
 
     def __init__(self, source: str, target: str, edge_type: str, **kwargs):

--- a/farms_network/core/node.pyx
+++ b/farms_network/core/node.pyx
@@ -70,13 +70,13 @@ cdef class PyNode:
         self.node.ninputs = 0
 
     def __dealloc__(self):
-        if self.node.name is not NULL:
-            free(self.node.name)
-        if self.node.model_type is not NULL:
-            free(self.node.model_type)
-        if self.node.parameters is not NULL:
-            free(self.node.parameters)
         if self.node is not NULL:
+            if self.node.name is not NULL:
+                free(self.node.name)
+            if self.node.model_type is not NULL:
+                free(self.node.model_type)
+            if self.node.parameters is not NULL:
+                free(self.node.parameters)
             free(self.node)
 
     def __init__(self, name: str, **kwargs):


### PR DESCRIPTION
Added fixes to `node.pyx` and `edge.pyx` in the `__dealloc__` to ensure that the object is checked to be `NULL` before its members avoiding null ref exceptions that could happen if the object were null.